### PR TITLE
Add splat.data.Fragment.resample

### DIFF
--- a/_splat.c
+++ b/_splat.c
@@ -1372,7 +1372,9 @@ PyDoc_STRVAR(Fragment_resample_doc,
 "fragment duration by the given ``ratio``.  When no ``rate`` is "
 "provided, the current sample rate is preserved.  By default, "
 "``ratio`` equals to 1.0 so the fragment duration remains unchanged "
-"when only resampling with a different rate.\n"
+"when only resampling with a different rate.  While ``rate`` needs to "
+"be an integer as a fragment's sample rate is fixed, ``ratio`` can be "
+"a signal to create modulations and effects.\n"
 "\n"
 "It is also worth noting that no filter is being applied by "
 "this function, so down-sampling to a lower rate or using a ``ratio`` "
@@ -1385,13 +1387,13 @@ static PyObject *Fragment_resample(Fragment *self, PyObject *args, PyObject *kw)
 
 	static char *kwlist[] = { "rate", "ratio", NULL };
 	unsigned rate = frag->rate;
-	double ratio = 1.0;
+	PyObject *ratio = splat_one;
 
 	struct splat_fragment old_frag;
 	unsigned c;
 	int res;
 
-	if (!PyArg_ParseTupleAndKeywords(args, kw, "|Id", kwlist,
+	if (!PyArg_ParseTupleAndKeywords(args, kw, "|IO", kwlist,
 					 &rate, &ratio))
 		return NULL;
 

--- a/_splat.c
+++ b/_splat.c
@@ -75,6 +75,9 @@ static PyObject *splat_sample_types;
 /* A Python float with the value of 0.0 */
 static PyObject *splat_zero;
 
+/* A Python float with the value of 1.0 */
+static PyObject *splat_one;
+
 #ifdef SPLAT_FAST
 sf_float_t splat_sine_step;
 const sf_float_t splat_fast_inc = { 0.0, 1.0, 2.0, 3.0 };
@@ -2088,6 +2091,8 @@ PyMODINIT_FUNC init_splat(void)
 	PyModule_AddObject(m, "_init_source_ratio", splat_init_source_ratio);
 	splat_zero = PyFloat_FromDouble(0.0);
 	PyModule_AddObject(m, "_zero", splat_zero);
+	splat_one = PyFloat_FromDouble(1.0);
+	PyModule_AddObject(m, "_one", splat_one);
 	splat_init_sample_types(m, "sample_types", splat_sample_types);
 
 	PyModule_AddStringConstant(m, "SAMPLE_TYPE", SPLAT_NATIVE_SAMPLE_TYPE);

--- a/_splat.h
+++ b/_splat.h
@@ -176,6 +176,9 @@ extern void splat_frag_lin2dB(struct splat_fragment *frag);
 extern void splat_frag_dB2lin(struct splat_fragment *frag);
 extern int splat_frag_offset(struct splat_fragment *frag, PyObject *offset_obj,
 			     double start);
+extern int splat_frag_resample(struct splat_fragment *frag,
+			       const struct splat_fragment *old_frag,
+			       unsigned rate, double time_ratio);
 
 /* ----------------------------------------------------------------------------
  * Signal & vector

--- a/_splat.h
+++ b/_splat.h
@@ -178,7 +178,7 @@ extern int splat_frag_offset(struct splat_fragment *frag, PyObject *offset_obj,
 			     double start);
 extern int splat_frag_resample(struct splat_fragment *frag,
 			       const struct splat_fragment *old_frag,
-			       unsigned rate, double time_ratio);
+			       unsigned rate, PyObject *time_ratio);
 
 /* ----------------------------------------------------------------------------
  * Signal & vector

--- a/doc/splat.rst
+++ b/doc/splat.rst
@@ -43,6 +43,7 @@ Fragment objects
    .. automethod:: splat.data.Fragment.dB2lin
    .. automethod:: splat.data.Fragment.offset
    .. automethod:: splat.data.Fragment.resize
+   .. automethod:: splat.data.Fragment.resample
    .. autoattribute:: splat.data.Fragment.rate
    .. autoattribute:: splat.data.Fragment.duration
    .. autoattribute:: splat.data.Fragment.channels

--- a/fast_test.py
+++ b/fast_test.py
@@ -136,6 +136,29 @@ def run_tests(freq=123.45, duration=30.0, phase=23.456, pts=None,
               normalize=False)
     cases.append('overtones-signal')
 
+    frag = splat.data.Fragment()
+    gen = splat.gen.SineGenerator(frag=frag)
+    gen.run(0.0, 5.678, 1234.56, levels=dB(-3))
+    ratio = 1.987
+    new_len = int(len(frag) * ratio)
+    rem = new_len % 4
+    if rem:
+        new_len -= rem
+    else:
+        new_len -= 4
+    frag.resample(ratio=ratio)
+    frag.resize(length=new_len)
+    frag.save('resample-float-{}.wav'.format(splat.SAMPLE_WIDTH))
+    cases.append('resample-float')
+
+    frag = splat.data.Fragment()
+    gen = splat.gen.SineGenerator(frag=frag)
+    gen.run(0.0, 5.678, 1234.56, levels=dB(-3))
+    ratio = 1.987
+    frag.resample(ratio=lambda x: ratio)
+    frag.save('resample-signal-{}.wav'.format(splat.SAMPLE_WIDTH))
+    cases.append('resample-signal')
+
     return cases
 
 def compare_all(cases, thr_dB=-40.0):

--- a/frag.c
+++ b/frag.c
@@ -592,12 +592,26 @@ int splat_frag_offset(struct splat_fragment *frag, PyObject *offset_obj,
     ---------------------------
 */
 
-int splat_frag_resample(struct splat_fragment *frag,
-			const struct splat_fragment *old_frag,
-			unsigned rate, double time_ratio)
+static sample_t splat_resample_quad(double x1, const sample_t *y, double x)
+{
+	const double y0 = y[0];
+	const double y1 = y[1];
+	const double y2 = y[2];
+	double k0, k1, k2;
+
+	k2 = (y2 + y0 - 2.0 * y1) / 2.0;
+	k1 = y1 - y0 + k2 * (1.0 - 2.0 * x1);
+	k0 = y1 + x1 * (y0 - y1) + k2 * (x1 * x1 - x1);
+
+	return k0 + x * k1 + x * x * k2;
+}
+
+int splat_frag_resample_float(struct splat_fragment *frag,
+			      const struct splat_fragment *old_frag,
+			      unsigned rate, double time_ratio)
 {
 	const double ratio = time_ratio * (double)rate / frag->rate;
-	const size_t max_j = old_frag->length - 2;
+	const size_t max_x0 = old_frag->length - 2;
 	unsigned c;
 
 	if (time_ratio <= 0.0) {
@@ -622,22 +636,96 @@ int splat_frag_resample(struct splat_fragment *frag,
 
 		for (i = 1; i < frag->length; ++i) {
 			const double x = i / ratio;
-			size_t j = x + 0.5;
-			double x1;
-			double y0, y1, y2;
-			double k0, k1, k2;
+			const size_t x0 = minmax(x + 0.5, 1, max_x0);
+			const sample_t *y = &old_frag->data[c][x0 - 1];
 
-			j = minmax(j, 1, max_j);
-			x1 = j;
-			y0 = old_frag->data[c][j - 1];
-			y1 = old_frag->data[c][j++];
-			y2 = old_frag->data[c][j];
-			k2 = (y2 + y0 - 2 * y1) / 2;
-			k1 = y1 - y0 + k2 * (1 - 2 * x1);
-			k0 = y1 + x1 * (y0 - y1) + k2 * (x1 * x1 - x1);
-			*to++ = k0 + x * k1 + x * x * k2;
+			*to++ = splat_resample_quad(x0, y, x);
 		}
 	}
 
 	return 0;
+}
+
+static int splat_frag_resample_signals(struct splat_fragment *frag,
+                                       const struct splat_fragment *old_frag,
+                                       unsigned rate, PyObject *ratio)
+{
+	const double rate_ratio = (double)rate / frag->rate;
+	const size_t max_x0 = old_frag->length - 2;
+	struct splat_signal sig;
+	size_t i;
+	double x;
+	size_t new_length;
+	unsigned c;
+	int stop;
+
+	if (splat_signal_init(&sig, frag->length, 0.0, &ratio, 1, rate))
+		return -1;
+
+	frag->rate = rate;
+	new_length = sig.length;
+	stop = 0;
+
+	for (c = 0; c < frag->n_channels; ++c)
+		frag->data[c][0] = old_frag->data[c][0];
+
+	i = 1;
+	x = 0.0;
+
+	while (!stop && (splat_signal_next(&sig) == SPLAT_SIGNAL_CONTINUE)) {
+		size_t j;
+
+		for (j = 0; j < sig.len; ++j, ++i) {
+			const double r = sig.vectors[0].data[j] * rate_ratio;
+			size_t x0;
+
+			if (r <= 0.0) {
+				PyErr_SetString(PyExc_ValueError,
+				       "resample time ratio must be positive");
+				goto error_free_sig;
+			}
+
+			x += 1.0 / r;
+
+			if (i >= frag->length)
+				if (splat_frag_resize(frag, frag->length * 1.5))
+					goto error_free_sig;
+
+			x0 = minmax(x, 1, max_x0);
+
+			for (c = 0; c < frag->n_channels; ++c) {
+				const sample_t *y = &old_frag->data[c][x0 - 1];
+
+				frag->data[c][i] =
+					splat_resample_quad(x0, y, x);
+			}
+
+			if (x0 == max_x0) {
+				stop = 1;
+				new_length = i;
+				break;
+			}
+		}
+	}
+
+	splat_frag_resize(frag, new_length);
+	splat_signal_free(&sig);
+
+	return (sig.stat == SPLAT_SIGNAL_ERROR) ? -1 : 0;
+
+error_free_sig:
+	splat_signal_free(&sig);
+
+	return -1;
+}
+
+int splat_frag_resample(struct splat_fragment *frag,
+                        const struct splat_fragment *old_frag,
+                        unsigned rate, PyObject *ratio)
+{
+	if (PyFloat_Check(ratio))
+		return splat_frag_resample_float(frag, old_frag, rate,
+						 PyFloat_AsDouble(ratio));
+	else
+		return splat_frag_resample_signals(frag, old_frag, rate,ratio);
 }

--- a/test.py
+++ b/test.py
@@ -31,6 +31,7 @@ import splat.interpol
 import splat.scales
 import splat.seq
 from splat import dB2lin as dB
+import compare
 
 splat.check_version((1, 5))
 
@@ -264,6 +265,35 @@ class FragmentTest(SplatTest):
                 self.assertAlmostEqual(
                     a, b, 3,
                     "Fragment data mismatch [{}] {} {}".format(i, a, b))
+
+    def test_frag_resample(self):
+        """Fragment.resample"""
+        def run_resample_test(source, duration, ratio, freq, rate, thr):
+            frag1 = splat.data.Fragment(duration=duration, channels=1)
+            source(frag1, 1.0, freq)
+            frag2 = frag1.dup()
+            frag2.resample(ratio=ratio, rate=rate)
+            new_length = int(len(frag1) * ratio * rate / frag1.rate)
+            self.assertEqual(len(frag2), new_length,
+                             "Incorrect resampled fragment length")
+            new_duration = float(new_length) / frag2.rate
+            self.assertAlmostEqual(frag2.duration, new_duration, self._places,
+                                   "Incorrect resampled fragment duration")
+            ref = splat.data.Fragment(length=len(frag2), channels=1,
+                                      rate=rate)
+            source(ref, 1.0, (freq / ratio))
+            delta = compare.frag_delta(ref, frag2)
+            err = splat.lin2dB(delta.get_peak()[0]['peak'])
+            self.assertLess(err, thr,
+                            "Interpolation error: {:.1f} dB".format(err))
+
+        for src, thr in [(splat.sources.sine, -60.0),
+                         (splat.sources.triangle, -27.0)]:
+            for f in [25.0, 1287.6]:
+                for d in [0.01, 0.8642]:
+                    for ratio in [0.35, (9.0 / 7.0)]:
+                        for rate in [48000, 44100, 96000]:
+                            run_resample_test(src, d, ratio, f, rate, thr)
 
 
 class InterpolTest(SplatTest):


### PR DESCRIPTION
Add splat.data.Fragment.resample function to change the sample rate of the fragment and also stretch it in time using quadratic interpolation.  A signal can also be used for the stretch ratio.

Warning: This does not run any filter so frequencies above sampling rate / 2 will cause spectrum overlap.