### PR TITLE
Fixup 0024

### DIFF
--- a/_splat.c
+++ b/_splat.c
@@ -79,8 +79,12 @@ static PyObject *splat_zero;
 static PyObject *splat_one;
 
 #ifdef SPLAT_FAST
-sf_float_t splat_sine_step;
+sf_float_t splat_fast_sine_step;
 const sf_float_t splat_fast_inc = { 0.0, 1.0, 2.0, 3.0 };
+#endif
+
+#if defined(SPLAT_NEON)
+sf_mask_t splat_fast_sine_mask;
 #endif
 
 #if defined(SPLAT_SSE)
@@ -2164,6 +2168,9 @@ PyMODINIT_FUNC init_splat(void)
 	PyModule_AddIntConstant(m, "SAMPLE_WIDTH", SPLAT_NATIVE_SAMPLE_WIDTH);
 
 #ifdef SPLAT_FAST
-	splat_sine_step = sf_set((float)splat_sine_table_len / M_PI);
+	splat_fast_sine_step = sf_set((float)splat_sine_table_len / M_PI);
+#endif
+#if defined(SPLAT_NEON)
+	splat_fast_sine_mask = vdupq_n_u32(splat_sine_table_mask);
 #endif
 }

--- a/_splat.h
+++ b/_splat.h
@@ -26,7 +26,7 @@
 
 /* Enable for speed using SIMD and 32-bit samples instead of 64-bit */
 #ifdef SPLAT_FAST
-#if defined(__ARM_NEON__)
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
 #include <arm_neon.h>
 #define SPLAT_NEON
 typedef float32x4_t sf_float_t;

--- a/_splat.h
+++ b/_splat.h
@@ -113,10 +113,12 @@ struct splat_sine_poly {
 
 extern const struct splat_sine_poly *splat_sine_table;
 extern const size_t splat_sine_table_len;
+extern const size_t splat_sine_table_mask;
 
 #ifdef SPLAT_FAST
 #define SPLAT_QUAD(_x) { (_x), (_x), (_x), (_x) }
-extern sf_float_t splat_sine_step;
+extern sf_float_t splat_fast_sine_step;
+extern sf_mask_t splat_fast_sine_mask;
 extern const sf_float_t splat_fast_inc;
 #endif
 

--- a/build-neon-v8
+++ b/build-neon-v8
@@ -1,0 +1,1 @@
+CFLAGS="-DSPLAT_FAST -mtune=cortex-a57 -O3" python setup.py build

--- a/doc/audio_formats.rst
+++ b/doc/audio_formats.rst
@@ -34,22 +34,23 @@ The following names are used to choose the audio file format in
 :py:meth:`splat.data.Fragment.open` and :py:meth:`splat.data.Fragment.save`:
 
 ``saf``
-  The Splat Audio Fragment file format is primarily made to export and import
-  Fragment objects without loosing any of the original samples precision.  By
-  default, they contain floating point samples with the native sample width.
-  It's also possible to explicitely specify the sample width which may result
-  in a conversion between 32-bit and 64-bit types with potential loss of
-  precision.  The ``saf`` format is useful when building complex splats to
-  avoid having to regenerate everything from scratch each time the code is run,
-  or to share some data across other splats.  There is currently no known
-  programme to play these files directly, although it's quite easy to import
-  one into a Fragment and export it again as WAV.
+  The Splat Audio Fragment file format is primarily made to export and
+  import Fragment objects without loosing any of the original samples
+  precision.  By default, they contain floating point samples with the
+  native sample width.  It's also possible to explicitely specify the
+  sample width which may result in a conversion between 32-bit and
+  64-bit types with potential loss of precision.  The ``saf`` format
+  is useful when building complex splats to avoid having to regenerate
+  everything from scratch each time the code is run, or to share some
+  data across other splats.  There is currently no known program to
+  play these files directly, although it's quite easy to import one
+  into a Fragment and export it again as WAV.
 
 ``wav``
-  This is for standard WAV audio files.  It uses the standard ``wave`` Python
-  module.  Any sample width value supported by the library can be used when
-  saving into a WAV file, but only 8-bit and 16-bit integer samples can be used
-  when opening a WAV file in Splat.
+  This is for standard WAV audio files.  It uses the standard ``wave``
+  Python module.  Any sample width value supported by the library can
+  be used when saving into a WAV file, but only 8-bit and 16-bit
+  integer samples can be used when opening a WAV file in Splat.
 
 
 Extra file formats with ``audiotools``

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -8,17 +8,18 @@
    Splat!
    ======
 
-   **Splat is a programme** to generate some audio data which you may call
-   music.  It's written in Python to make it easy to use, and all the crucial
-   processing parts are implemented in C for fast number crunshing.  It's
-   distributed under the terms of the **GNU LGPL v3** so you remain a free
-   individual when you use it.
+   **Splat is a program** to generate some audio data which you may
+   call music.  It's written in Python to make it easy to use, and all
+   the crucial processing parts are implemented in C for fast number
+   crunshing.  It's distributed under the terms of the **GNU LGPL v3**
+   so you remain a free individual when you use it.
 
-   **Splat is not a programme** to generate **live** audio in real time, at
-   least not at the moment.  So it's better suited to the studio than to the
-   stage.
+   **Splat is not a program** to generate **live** audio in real time,
+   at least not at the moment.  So it's better suited to the studio
+   than to the stage.
 
-   Here's a very small **Splat** example which creates a beep 440Hz sound:
+   Here's a very small **Splat** example which creates a beep 440Hz
+   sound:
 
    .. code-block:: python
 
@@ -26,7 +27,7 @@
 
        gen = splat.SineGenerator(splat.Fragment(), [splat.filters.linear_fade])
        gen.run(440.0, 0.0, 1.0)
-       gen.frag.save("A440.wav")
+       gen.frag.save("440-Hz.wav")
 
 
 Splat manual

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -39,8 +39,9 @@ code, only on the standard Python library.
 Beep
 ----
 
-As a first concrete exemple, here's a very small splat which creates a 440Hz
-sound for 1 second, with short fade-in and fade-out, and saves it in a file:
+As a first concrete example, here's a very small splat which creates a
+440Hz sound for 1 second, with short fade-in and fade-out, and saves
+it in a file:
 
 .. code-block:: python
 
@@ -50,7 +51,19 @@ sound for 1 second, with short fade-in and fade-out, and saves it in a file:
     gen = splat.gen.SineGenerator()
     gen.filters = [splat.filters.linear_fade]
     gen.run(0.0, 1.0, 440.0)
-    gen.frag.save("A440.wav")
+    gen.frag.save("440-Hz.wav")
+
+Skipping the import statements, this first creates the sound generator
+object: a :py:class:`splat.gen.SineGenerator` to generate sine waves.
+Then it sets a :py:func:`splat.filters.linear_fade` filter which will
+run on the generator output to progressively ramp up and down (fade in
+and out) the volume at the beginning and end of the generated audio.
+Then the generator is being run, starting at time 0 for 1 second and
+at a frequency of 440 Hz (standard concert pitch for the A note...).
+Generators have a piece of memory associated with them to keep the
+data they produce, so that's where the sine wave went.  Finally the
+audio is saved in a file which you can play any time and share with
+your friends.
 
 
 Principles

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -204,7 +204,13 @@ Your Splat program will most likely do some or all of the following things:
 #. Run any filters or edit the fragments.
 #. Finally mix all the fragments together and save the result into a file.
 
-.. rubric:: And now, in stereo (see `example.py on Github <https://github.com/verdigris/splat/blob/master/example.py>`_):
+.. raw:: latex
+
+   \newpage
+
+.. rubric:: And now, in stereo
+
+Below is a more advanced example, also this `example.py on Github <https://github.com/verdigris/splat/blob/master/example.py>`_:
 
 .. literalinclude:: ../example.py
    :language: python

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -180,7 +180,7 @@ indexed.
 Typical Splat
 -------------
 
-Your Splat programme will most likely do some or all of the following things:
+Your Splat program will most likely do some or all of the following things:
 
 #. Create a :py:class:`splat.gen.Genarator` which contains a fragment and a
    sound source.

--- a/example.py
+++ b/example.py
@@ -1,13 +1,17 @@
-import splat.gen
 import splat.data
 import splat.filters
+import splat.gen
 import splat.interpol
+import splat.scales
 from splat import dB2lin as dB
+
+# Create a harmonic scale to use note names rather than frequencies
+scale = splat.scales.HarmonicScale()
 
 # Create a triangle wave generator and produce some simple sound with it
 triangle = splat.gen.TriangleGenerator()
 triangle.filters = [splat.filters.linear_fade]
-triangle.run(0.0, 2.8, 220.0, levels=dB(-6.0))
+triangle.run(0.0, 2.8, scale['A-1'], levels=dB(-6.0))
 
 # Create a spline to be used as an envelope (amplitude modulation) in dB
 envelope_pts = [(0.0, -100.0), (0.5, -12.0), (1.0, -0.5, 0.0),
@@ -16,12 +20,11 @@ envelope = splat.interpol.spline(envelope_pts, dB2lin=True)
 
 # Create a sine wave generator and run it with the envelope
 sine = splat.gen.SineGenerator()
-sine.run(0.0, 2.5, 330.0, levels=tuple(envelope.value for i in range(2)))
+sine.run(0.0, 2.5, scale['E-1'], levels=envelope.signal)
 
 # Mix the generated fragments together, add some reverb and save the result
 master = splat.data.Fragment()
 master.mix(triangle.frag, 0.5)
 master.mix(sine.frag, 0.75)
 splat.filters.reverb(master, splat.filters.reverb_delays())
-master.normalize()
 master.save('example.wav')

--- a/fast_test.py
+++ b/fast_test.py
@@ -23,7 +23,7 @@ import splat.gen
 import splat.data
 import splat
 from splat import dB2lin as dB
-import compare
+import splat.tools.compare
 
 def run_tests(freq=123.45, duration=30.0, phase=23.456, pts=None,
               overtones=None, verbose=False):
@@ -165,7 +165,7 @@ def compare_all(cases, thr_dB=-40.0):
     ret = True
     for c in cases:
         f1, f2 = ('-'.join([c, str(w)]) + '.wav' for w in (64, 32))
-        delta_dB = compare.file_peak_delta_dB(f1, f2)
+        delta_dB = splat.tools.compare.file_peak_delta_dB(f1, f2)
         if delta_dB < thr_dB:
             res = 'OK'
         else:

--- a/gen_sine_table.py
+++ b/gen_sine_table.py
@@ -23,6 +23,7 @@ def gen_table(pols, out=print):
     out()
     out("const struct splat_sine_poly *splat_sine_table = _sine_table;")
     out("const size_t splat_sine_table_len = {};".format(len(pols)))
+    out("const size_t splat_sine_table_mask = 0x{:x};".format(len(pols) - 1))
 
 def main(argv):
     ranges = {
@@ -34,6 +35,10 @@ def main(argv):
     parser.add_argument('--range', default='half', choices=ranges,
                         help="Range of the points relative to 2 * PI")
     args = parser.parse_args(argv[1:])
+
+    if math.log(args.n, 2) % 1.0:
+        print("The number of points needs to be a power of 2")
+        return False
 
     spline = make_spline(args.n, args.m)
     print("/* Automatically generated file - read the manual */")

--- a/rebuild-fast-test.sh
+++ b/rebuild-fast-test.sh
@@ -2,7 +2,27 @@
 
 set -e
 
-simd="${1-sse}"
+simd="$1"
+
+if [ -z "$simd" ]; then
+    arch=$(uname -m)
+
+    case "$arch" in
+        "armv7l")
+            simd=neon-v7
+            ;;
+	"aarch64")
+	    simd=neon-v8
+	    ;;
+        "x86_64")
+            simd=sse
+            ;;
+        *)
+            echo "Unknown architecture, please specify"
+            ;;
+    esac
+fi
+
 [ -x build-"$simd" ] || {
     echo "Unsupported SIMD mode: $simd"
     exit 1

--- a/sine_table.c
+++ b/sine_table.c
@@ -392,3 +392,4 @@ __attribute__ ((aligned (16))) = {
 
 const struct splat_sine_poly *splat_sine_table = _sine_table;
 const size_t splat_sine_table_len = 64;
+const size_t splat_sine_table_mask = 0x3f;

--- a/source.c
+++ b/source.c
@@ -906,7 +906,7 @@ static float32x4_t splat_fast_sine(float32x4_t x)
 	a = vaddq_f32(a, (float32x4_t)neg);
 
 	/* m = int(a * table_len / M_PI) */
-	m = vcvtq_u32_f32(vmulq_f32(a, splat_sine_step));
+	m = vcvtq_u32_f32(vmulq_f32(a, splat_fast_sine_step));
 
 	/* polyq1..4 = transpose(table[m]) */
 	/* y = p0 + (x * p1) + (x^2 * p2) + (x^3 * p3) */
@@ -972,7 +972,7 @@ static __m128 splat_fast_sine(__m128 x)
 	a = _mm_sub_ps(a, neg);
 
 	/* m = int(a * table_len / M_PI) */
-	m = _mm_cvttps_epi32(_mm_mul_ps(a, splat_sine_step));
+	m = _mm_cvttps_epi32(_mm_mul_ps(a, splat_fast_sine_step));
 
 	/* poly1..4 = transpose(table[m]) */
 	y = _mm_load_ps(splat_sine_table[mf[0]].coef);

--- a/source.c
+++ b/source.c
@@ -900,13 +900,9 @@ static float32x4_t splat_fast_sine(float32x4_t x)
 	a = vcvtq_f32_u32(vcvtq_u32_f32(a));
 	a = vmlsq_f32(x, a, pi);
 
-	/* if a < 0 then a += M_PI */
-	neg = vcltq_f32(a, vdupq_n_f32(0.0));
-	neg = vandq_u32(neg, (uint32x4_t)pi);
-	a = vaddq_f32(a, (float32x4_t)neg);
-
-	/* m = int(a * table_len / M_PI) */
-	m = vcvtq_u32_f32(vmulq_f32(a, splat_fast_sine_step));
+	/* m = int(x * table_len / M_PI) & table_mask */
+	m = vcvtq_u32_f32(vmulq_f32(x, splat_fast_sine_step));
+	m = vandq_u32(m, splat_fast_sine_mask);
 
 	/* polyq1..4 = transpose(table[m]) */
 	/* y = p0 + (x * p1) + (x^2 * p2) + (x^3 * p3) */

--- a/source.c
+++ b/source.c
@@ -111,6 +111,9 @@ static void _splat_sine_signals(struct splat_fragment *frag,
 			aq[c] = (sf_float_t *)
 				sig->vectors[SIG_SINE_AMP + c].data;
 
+		for (; c < SPLAT_MAX_CHANNELS; ++c)
+			aq[c] = NULL;
+
 		for (j = 0; j < sig->len; i += 4, j += 4) {
 			sf_float_t x;
 			sf_float_t f;
@@ -538,6 +541,9 @@ static void _splat_overtones_mixed(struct splat_fragment *frag,
 			amq[c] = (sf_float_t *)
 				sig->vectors[SIG_OT_AMP + c].data;
 
+		for (; c < SPLAT_MAX_CHANNELS; ++c)
+			amq[c] = NULL;
+
 		for (j = 0; j < sig->len; i += 4, j += 4) {
 			const struct splat_overtone *ot;
 			const sf_float_t f = *fq++;
@@ -555,6 +561,11 @@ static void _splat_overtones_mixed(struct splat_fragment *frag,
 
 			for (c = 0; c < frag->n_channels; ++c) {
 				aq[c] = *amq[c]++;
+				y[c] = sf_zero();
+			}
+
+			for (; c < SPLAT_MAX_CHANNELS; ++c) {
+				aq[c] = sf_zero();
 				y[c] = sf_zero();
 			}
 
@@ -700,6 +711,9 @@ static void _splat_overtones_signal(struct splat_fragment *frag,
 			amq[c] = (sf_float_t *)
 				sig->vectors[SIG_OT_AMP + c].data;
 
+		for (; c < SPLAT_MAX_CHANNELS; ++c)
+			amq[c] = NULL;
+
 		for (j = 0; j < sig->len; i += 4, j += 4) {
 			const struct splat_vector *otv = &sig->vectors[sig_ot];
 			const struct splat_overtone *ot;
@@ -719,6 +733,11 @@ static void _splat_overtones_signal(struct splat_fragment *frag,
 
 			for (c = 0; c < frag->n_channels; ++c) {
 				aq[c] = *amq[c]++;
+				y[c] = sf_zero();
+			}
+
+			for (; c < SPLAT_MAX_CHANNELS; ++c) {
+				aq[c] = sf_zero();
 				y[c] = sf_zero();
 			}
 


### PR DESCRIPTION
A series of fixes in preparation for `build-0024`:

* fix compiler warnings when using SIMD intrinsics on GCC v6
* fix AArch64 support with SIMD (NEON)
* fix missing imports
* fix out-of-bound error in fast mode sine wave table on NEON
* clean up docs